### PR TITLE
Addressed Issue-18

### DIFF
--- a/content/past-issues/volume-i-issue-1/_index.md
+++ b/content/past-issues/volume-i-issue-1/_index.md
@@ -2,5 +2,6 @@
 title: "Volume I, Issue 1"
 description: "The inaugural issue, Spring 2015"
 issueIndex: "1"
+dg_pid: 28279
 ---
 This past volume is available on our new static platform only as a downloadable PDF. However, its content is available as [Issue 1](https://rootstalk-archive.grinnell.edu/issue/1) on our [legacy website](https://rootstalk-archive.grinnell.edu) as a collection of downloadable PDF documents.

--- a/content/past-issues/volume-ii-issue-1/_index.md
+++ b/content/past-issues/volume-ii-issue-1/_index.md
@@ -2,5 +2,6 @@
 title: "Volume II, Issue 1"
 description: "Fall 2015"
 issueIndex: "2"
+dg_pid: 28280
 ---
 This past volume is not yet available on our new static platform. However, its content is available as [Issue 2](https://rootstalk-archive.grinnell.edu/issue/2) on our [legacy website](https://rootstalk-archive.grinnell.edu) as a collection of downloadable PDF documents.

--- a/content/past-issues/volume-ii-issue-2/_index.md
+++ b/content/past-issues/volume-ii-issue-2/_index.md
@@ -2,5 +2,6 @@
 title: "Volume II, Issue 2"
 description: "Spring 2016"
 issueIndex: "3"
+dg_pid: 28281
 ---
 This past volume is not yet available on our new static platform. However, its content is available as [Issue 3](https://rootstalk-archive.grinnell.edu/issue/3) on our [legacy website](https://rootstalk-archive.grinnell.edu) as a collection of downloadable PDF documents.

--- a/content/past-issues/volume-iii-issue-1/_index.md
+++ b/content/past-issues/volume-iii-issue-1/_index.md
@@ -2,5 +2,6 @@
 title: "Volume III, Issue 1"
 description: "Fall 2016"
 issueIndex: "4"
+dg_pid: 28282
 ---
 This past volume is not yet available on our new static platform. However, its content is available as [Issue 4](https://rootstalk-archive.grinnell.edu/issue/4) on our [legacy website](https://rootstalk-archive.grinnell.edu) as a collection of downloadable PDF documents.

--- a/content/past-issues/volume-iii-issue-2/_index.md
+++ b/content/past-issues/volume-iii-issue-2/_index.md
@@ -2,5 +2,6 @@
 title: "Volume III, Issue 2"
 description: "Spring 2017"
 issueIndex: "5"
+dg_pid: 28283
 ---
 This past volume is not yet available on our new static platform. However, its content is available as [Issue 5](https://rootstalk-archive.grinnell.edu/issue/5) on our [legacy website](https://rootstalk-archive.grinnell.edu) as a collection of downloadable PDF documents.

--- a/content/past-issues/volume-iv-issue-1/_index.md
+++ b/content/past-issues/volume-iv-issue-1/_index.md
@@ -2,5 +2,6 @@
 title: "Volume IV, Issue 1"
 description: "Fall 2017"
 issueIndex: "6"
+dg_pid: 28284
 ---
 This past volume is not yet available on our new static platform. However, its content is available as [Issue 6](https://rootstalk-archive.grinnell.edu/issue/6) on our [legacy website](https://rootstalk-archive.grinnell.edu) as a collection of downloadable PDF documents.

--- a/content/past-issues/volume-iv-issue-2/_index.md
+++ b/content/past-issues/volume-iv-issue-2/_index.md
@@ -3,5 +3,6 @@ title: "Volume IV, Issue 2"
 description: "Spring 2018"
 issueIndex: "7"
 sidebar: false
+dg_pid: 28285
 ---
 This past volume is not yet available on our new static platform. However, its content is available as [Issue 7](https://rootstalk-archive.grinnell.edu/issue/7) on our [legacy website](https://rootstalk-archive.grinnell.edu) as a collection of downloadable PDF documents.

--- a/content/past-issues/volume-v-issue-1/_index.md
+++ b/content/past-issues/volume-v-issue-1/_index.md
@@ -2,4 +2,6 @@
 title: "Volume V, Issue 1"
 description: "Current Issue -- Fall 2018"
 sidebar: false
+dg_pid: 28286
 ---
+This past volume was the first made avialable on this version of the website. 

--- a/layouts/past-issues/list.html
+++ b/layouts/past-issues/list.html
@@ -1,0 +1,37 @@
+{{ define "title" }}{{ .Site.Title }}{{ end }}
+
+{{ define "meta" }}
+{{- partial "section_meta.html" . -}}
+{{- partial "single_meta.html" . -}}
+{{- partial "opengraph_meta.html" . -}}
+{{ end }}
+
+{{ define "header" }}
+{{- partial "section_json_ld.html" . -}}
+{{ end }}
+
+{{ define "main" -}}
+<main class="main layout__main">
+  <article class="{{ with .Section }}section-{{ . | urlize }} {{ end }}single-view">
+    <div class="content">
+
+      {{ .Content }}
+
+      {{ range (.Page.Sections.ByParam "issueIndex").Reverse }}
+        <a href="{{ .RelPermalink }}" id="current_issue_img" style="--coverurl: url('{{.RelPermalink}}cover.png') ;">
+          <div id="current_issue_text">
+            <p class="issue">{{ .Title }}</p>
+            <p class="season">{{ .Params.description | markdownify }}</p>
+          </div>
+        </a>
+
+        <div id="download_link_container">
+          <div class="download_link"><a href="https://digital.grinnell.edu/islandora/object/grinnell:{{ .Params.dg_pid }}/datastream/OBJ/download">Download a PDF Copy of This Issue</a></div>
+        </div>
+        <hr>
+      {{ end }}
+
+    </div>
+  </article>
+</main>
+{{ end }}


### PR DESCRIPTION
I've implemented the scheme proposed in #18 with a new `dg_pid` parameter in each past-issue front matter.  `Volume V, Issue 1` still needs some attention since it is  the first of the new site's issues to become a "past issue".

I've tested this locally with good results so I'm going to merge this change so that others can benefit from the change.

Note that in making this change I eliminated the old "Download Print-Friendly PDF" and "Download interactive PDF", and replaced both with a single link that say "Download a PDF Copy of This Issue".  I did this because some of the issues appear to have print-friendly PDFs only, but an interactive PDF was selected for this link wherever one was available.